### PR TITLE
Fix docstring for modsqrt

### DIFF
--- a/ecc/math_utils.py
+++ b/ecc/math_utils.py
@@ -8,7 +8,7 @@ def modsqrt(a: int, p: int) -> int | None:
     Find a quadratic residue (mod p) of 'a'.
     Solve the congruence of the form: x^2 = a (mod p).
     And returns x. Note that p - x is also a root.
-    None is returned is no square root exists for these a and p.
+    None is returned if no square root exists for these a and p.
     The Tonelli-Shanks algorithm is used (except for some simple
     cases in which the solution is known from an identity).
     This algorithm runs in polynomial time (unless the generalized


### PR DESCRIPTION
## Summary
- correct grammar in `modsqrt` docstring

## Testing
- `flake8 . --max-line-length=88` *(fails: command not found)*
- `mypy .` *(fails: missing stubs for setuptools)*
- `python3 -m unittest discover tests`