### PR TITLE
Add length check to encode

### DIFF
--- a/ecc/curve.py
+++ b/ecc/curve.py
@@ -284,6 +284,8 @@ class TwistedEdwardsCurve(Curve):
 
 def encode(plaintext: bytes, curve: Curve) -> AffinePoint:
     # Here we assume the length can be represented in one byte.
+    if len(plaintext) >= 256:
+        raise ValueError("plaintext too long")
     byte_len = len(plaintext).to_bytes(1, "little")
     plaintext = byte_len + plaintext
     while True:

--- a/tests/test_cipher.py
+++ b/tests/test_cipher.py
@@ -72,3 +72,10 @@ class TestEcdsa(unittest.TestCase):
                 signature = cipher.ecdsa_sign(plaintext_bytes, pri_key, curve_)
                 verify = cipher.ecdsa_verify(plaintext_bytes[:-1], signature, pub_key)
                 self.assertFalse(verify)
+
+
+class TestEncode(unittest.TestCase):
+    def test_plaintext_too_long(self):
+        long_plaintext = os.urandom(256)
+        with self.assertRaises(ValueError):
+            curve.encode(long_plaintext, registry.P256)


### PR DESCRIPTION
## Summary
- check for max plaintext length in `curve.encode`
- add regression test for long plaintext

## Testing
- `pytest -q` *(fails: command not found)*